### PR TITLE
Clarify details of now `stdin` is implemented

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,13 +34,18 @@ unicorns
 
 Get `stdin` as a string.
 
-Returns a promise.
+Returns a promise that is resolved when the 'end' event fires on the `stdin` stream, indicating that there is no more data to be read.
+
+In a TTY context, a promise that resolves to an empty string is returned.
 
 ### stdin.buffer()
 
 Get `stdin` as a buffer.
 
-Returns a promise.
+Returns a promise that is resolved when the 'end' event fires on the `stdin` stream, indicating that there is no more data to be read.
+
+In a TTY context, a promise that resolves to an empty buffer is returned.
+
 
 
 ## License


### PR DESCRIPTION
It wasn't clear from the docs how a flowing stream would be converted to a static stream. 

These updated docs clarify that the *entire* stream is captured by waiting for the `end` event. It also notes that methods function differently in TTY context.