### PR TITLE
Add TTY support. Fix getStdin.buffer() and tests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function (opt) {
 		stdin.on('readable', function () {
 			var chunk;
 			while ((chunk = stdin.read())) {
-				if (stdin.isTTY && tty && handleTTY(chunk)) {
+				if (tty && handleTTY(chunk)) {
 					return;
 				}
 				ret += chunk;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-stdin",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Get stdin as a string or buffer",
   "license": "MIT",
   "repository": "sindresorhus/get-stdin",
@@ -13,7 +13,7 @@
     "node": ">=0.12.0"
   },
   "scripts": {
-    "test": "xo && ava test.js && echo unicorns | node test-real.js"
+    "test": "xo && ava --verbose test.js && ava --verbose test-tty.js && echo unicorns | node test-real.js"
   },
   "files": [
     "index.js"
@@ -29,7 +29,7 @@
     "read"
   ],
   "devDependencies": {
-    "ava": "^0.2.0",
+    "ava": "^0.9.0",
     "buffer-equals": "^1.0.3",
     "xo": "*"
   }

--- a/readme.md
+++ b/readme.md
@@ -32,11 +32,11 @@ unicorns
 
 Both methods returns a promise that is resolved when the `end` event fires on the `stdin` stream, indicating that there is no more data to be read.
 
-### getStdin()
+### getStdin([opt])
 
 Get `stdin` as a string.
 
-In a TTY context, a promise that resolves to an empty string is returned.
+In a TTY context, a promise that resolves to an empty string is returned, unless opt.tty or getStdin.tty is true.
 
 ### getStdin.buffer()
 
@@ -44,6 +44,21 @@ Get `stdin` as a buffer.
 
 In a TTY context, a promise that resolves to an empty buffer is returned.
 
+### getStdin.tty = true/false
+
+Set global TTY handling.  When true, accepts input from TTY until a new line beginning with ^d or ^z is entered. (default = false)
+
+When enabled for the example above:
+
+``` 
+$ example.js
+foobar
+barfoo
+^d
+// =>
+foobar
+barfoo
+```
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -46,12 +46,12 @@ In a TTY context, a promise that resolves to an empty buffer is returned.
 
 ### getStdin.tty = true/false
 
-Set global TTY handling.  When true, accepts input from TTY until a new line beginning with ^d or ^z is entered. (default = false)
+Set global TTY handling.  When true, accepts input from TTY until a new line beginning with Ctrl-d or Ctrl-z (ASCII 04 and 26) is entered. (default = false)
 
 When enabled for the example above:
 
 ``` 
-$ example.js
+$ node example.js
 foobar
 barfoo
 ^d

--- a/test-tty.js
+++ b/test-tty.js
@@ -1,0 +1,46 @@
+import test from 'ava';
+import fn from './';
+process.stdin.isTTY = true;
+
+test.beforeEach(() => {
+	process.stdin.removeAllListeners();
+});
+
+test.serial('get stdin in TTY mode with ^d', async t => {
+	setImmediate(() => {
+		process.stdin.push('unicorn');
+		process.stdin.push('\u0004\n');
+	});
+
+	t.is(await fn({tty: true}), 'unicorn');
+});
+
+test.serial('get stdin in TTY mode with ^z', async t => {
+	setImmediate(() => {
+		process.stdin.push('unicorn');
+		process.stdin.push('\u001a\n');
+	});
+
+	t.is(await fn({tty: true}), 'unicorn');
+});
+
+test.serial('get stdin in TTY mode using global tty', async t => {
+	setImmediate(() => {
+		process.stdin.push('unicorn');
+		process.stdin.push('\u0004\n');
+	});
+
+	fn.tty = true;
+	t.is(await fn(), 'unicorn');
+});
+
+test.serial('get empty string in non-TTY mode with option override', async t => {
+	setImmediate(() => {
+		process.stdin.push('unicorn111');
+		process.stdin.push('\u0004\n');
+		process.stdin.emit('end');
+	});
+
+	fn.tty = true;
+	t.is(await fn({tty: false}), '');
+});

--- a/test-tty.js
+++ b/test-tty.js
@@ -36,7 +36,7 @@ test.serial('get stdin in TTY mode using global tty', async t => {
 
 test.serial('get empty string in non-TTY mode with option override', async t => {
 	setImmediate(() => {
-		process.stdin.push('unicorn111');
+		process.stdin.push('unicorn');
 		process.stdin.push('\u0004\n');
 		process.stdin.emit('end');
 	});

--- a/test.js
+++ b/test.js
@@ -2,6 +2,10 @@ import test from 'ava';
 import bufferEquals from 'buffer-equals';
 import fn from './';
 
+test.beforeEach(() => {
+	process.stdin.removeAllListeners();
+});
+
 test.serial('get stdin', async t => {
 	process.stdin.isTTY = false;
 
@@ -19,14 +23,15 @@ test.serial('get empty string when no stdin', async t => {
 });
 
 test.serial('get stdin as a buffer', t => {
+	t.plan(2);
 	process.stdin.isTTY = false;
-
-	const promise = fn.buffer(data => {
-		t.true(bufferEquals(data, new Buffer('unicorns')));
-		t.is(data.toString().trim(), 'unicorns');
+	const promise = fn.buffer().then(data => {
+		t.true(bufferEquals(data, new Buffer('unicorns-foobar')));
+		t.is(data.toString().trim(), 'unicorns-foobar');
 	});
 
-	process.stdin.push(new Buffer('unicorns'));
+	process.stdin.push('unicorns');
+	process.stdin.push(new Buffer('-foobar'));
 	process.stdin.emit('end');
 
 	return promise;


### PR DESCRIPTION
This implements TTY support per issue #1.

It also fixes the original tests by clearing listeners before each test, and fixing the Promise test for getStdin.buffer() where the assertions were never being called.

With the test fixed, getStdin.buffer() was returning:
```
  TypeError: buf.copy is not a function
    at ReadStream.<anonymous> (D:\dev\github\get-stdin\index.js:56:19)
    at Test.fn (D:\dev\github\get-stdin\test.js:36:16)
```
So fixed this as well, with line 46 in index.js by forcing a new Buffer();

I can submit separate PRs if you prefer -- trying to save myself the hassle of cheery-picking or creating a separate branch!