### PR TITLE
Exclude test files from xo

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.12.0"
   },
   "scripts": {
-    "test": "xo && ava test.js test-buffer.js && echo unicorns | node test-real.js"
+    "test": "xo index.js && ava test.js test-buffer.js && echo unicorns | node test-real.js"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
Fixes `npm test` command, with this https://github.com/sindresorhus/get-stdin/pull/14 will pass.

I've excluded the tests from `xo` as they were failing, not sure if you'd rather they were linted as well but with overridden rules?