### PR TITLE
Load stdin lazily

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 'use strict';
-var stdin = process.stdin;
+var stdin = null;
 
 module.exports = function () {
+	if (stdin === null) {
+		stdin = process.stdin;
+	}
+
 	var ret = '';
 
 	return new Promise(function (resolve) {
@@ -27,6 +31,10 @@ module.exports = function () {
 };
 
 module.exports.buffer = function () {
+	if (stdin === null) {
+		stdin = process.stdin;
+	}
+
 	var ret = [];
 	var len = 0;
 


### PR DESCRIPTION
I encountered this while tracking a bug in an Atom extension I used. Apparently, in Atom accessing `process.stdin` throws an exception. This makes a huge library unusable there, since calling `require('get-stdin')` accesses `process.stdin`, even though the extension doesn't use it.