### PR TITLE
[WIP] Only wait for stdin for a little bit

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,17 @@ module.exports = () => {
 			return;
 		}
 
+		const timeout = setTimeout(() => {
+			resolve(ret);
+		}, 100);
+
+		stdin.unref();
 		stdin.setEncoding('utf8');
 
 		stdin.on('readable', () => {
+			clearTimeout(timeout);
+			stdin.ref();
+
 			let chunk;
 
 			while ((chunk = stdin.read())) {
@@ -36,7 +44,16 @@ module.exports.buffer = () => {
 			return;
 		}
 
+		const timeout = setTimeout(() => {
+			resolve(new Buffer(''));
+		}, 100);
+
+		stdin.unref();
+
 		stdin.on('readable', () => {
+			clearTimeout(timeout);
+			stdin.ref();
+
 			let chunk;
 
 			while ((chunk = stdin.read())) {

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 > Get [stdin](https://nodejs.org/api/process.html#process_process_stdin) as a string or buffer
 
+This module expects stdin to be written right away. It's not intended for stdin being written at some arbitrary time.
+
 
 ## Install
 
@@ -16,21 +18,26 @@ $ npm install --save get-stdin
 // example.js
 const getStdin = require('get-stdin');
 
-getStdin().then(str => {
-	console.log(str);
-	//=> 'unicorns'
+getStdin().then(stdin => {
+	if (stdin.length > 0) {
+		console.log('stdin:', str);
+	} else {
+		console.log('input:', process.argv[2]);
+	}
 });
 ```
 
 ```
 $ echo unicorns | node example.js
-unicorns
+stdin: unicorns
+$ node example.js unicorns
+input: unicorns
 ```
 
 
 ## API
 
-Both methods returns a promise that is resolved when the `end` event fires on the `stdin` stream, indicating that there is no more data to be read.
+Both methods returns a promise that is resolved when the `end` event fires on the `stdin` stream or after 100ms, indicating that there is no more data to be read.
 
 ### getStdin()
 


### PR DESCRIPTION
For this module, we only really care about stdin that is written right away, like when the process is piped.

This has the benefit of letting us easily add a fallback when there's no stdin.

Fixes #13 

---

I'm not sure this is the right solution, but according to the internet there's no other way than setting a timeout. What should the timeout value be? I have no idea, 100ms seems ok though. @qix- What do you think?

// @silverwind @SamVerschueren @lukechilds