### PR TITLE
Unify how to get stdin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,52 +1,34 @@
 'use strict';
 const stdin = process.stdin;
 
-module.exports = () => {
-	let ret = '';
+function getStdin(serializer) {
+	return () => {
+		const ret = [];
+		let len = 0;
 
-	return new Promise(resolve => {
-		if (stdin.isTTY) {
-			resolve(ret);
-			return;
-		}
-
-		stdin.setEncoding('utf8');
-
-		stdin.on('readable', () => {
-			let chunk;
-
-			while ((chunk = stdin.read())) {
-				ret += chunk;
+		return new Promise(resolve => {
+			if (stdin.isTTY) {
+				const buffer = Buffer.from('');
+				resolve(serializer(buffer));
+				return;
 			}
+
+			stdin.on('readable', () => {
+				let chunk;
+
+				while ((chunk = stdin.read())) {
+					ret.push(chunk);
+					len += chunk.length;
+				}
+			});
+
+			stdin.on('end', () => {
+				const buffer = Buffer.concat(ret, len);
+				resolve(serializer(buffer));
+			});
 		});
+	};
+}
 
-		stdin.on('end', () => {
-			resolve(ret);
-		});
-	});
-};
-
-module.exports.buffer = () => {
-	const ret = [];
-	let len = 0;
-
-	return new Promise(resolve => {
-		if (stdin.isTTY) {
-			resolve(Buffer.from(''));
-			return;
-		}
-
-		stdin.on('readable', () => {
-			let chunk;
-
-			while ((chunk = stdin.read())) {
-				ret.push(chunk);
-				len += chunk.length;
-			}
-		});
-
-		stdin.on('end', () => {
-			resolve(Buffer.concat(ret, len));
-		});
-	});
-};
+module.exports = getStdin(buffer => buffer.toString());
+module.exports.buffer = getStdin(buffer => buffer);

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports.buffer = () => {
 
 	return new Promise(resolve => {
 		if (stdin.isTTY) {
-			resolve(new Buffer(''));
+			resolve(Buffer.from(''));
 			return;
 		}
 

--- a/test-buffer.js
+++ b/test-buffer.js
@@ -6,15 +6,15 @@ test.serial('get stdin', async t => {
 	process.stdin.isTTY = false;
 
 	const promise = m.buffer();
-	process.stdin.push(new Buffer('uni'));
-	process.stdin.push(new Buffer('corns'));
+	process.stdin.push(Buffer.from('uni'));
+	process.stdin.push(Buffer.from('corns'));
 	process.stdin.emit('end');
 	const data = await promise;
-	t.true(data.equals(new Buffer('unicorns')));
+	t.true(data.equals(Buffer.from('unicorns')));
 	t.is(data.toString(), 'unicorns');
 });
 
 test.serial('get empty buffer when no stdin', async t => {
 	process.stdin.isTTY = true;
-	t.true((await m.buffer()).equals(new Buffer('')));
+	t.true((await m.buffer()).equals(Buffer.from('')));
 });


### PR DESCRIPTION
I unified the main method for get the stdin and added a serializer method for determinate if you want an string or buffer output.

Also `new Buffer` → `Buffer.from` 😄