### PR TITLE
Avoid using deprecated Buffer constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports.buffer = () => {
 
 	return new Promise(resolve => {
 		if (stdin.isTTY) {
-			resolve(new Buffer('')); // eslint-disable-line unicorn/no-new-buffer
+			resolve(Buffer.concat([]));
 			return;
 		}
 


### PR DESCRIPTION
`Buffer.concat([])` returns an empty buffer all the way down to Node.js 0.8.x.
This also makes the linter happier and removes an `// eslint-disable-line`

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor